### PR TITLE
Update Py 3.6 install instructions

### DIFF
--- a/preparation.rst
+++ b/preparation.rst
@@ -3,11 +3,9 @@ Preparation
 
 Before coming to the tutorial, please do the following:
 
-1. Have Python 3.6 installed in your laptop. **Note:** It's important that you're running Python 3.6 (or above) because we will use some of the new features added in 3.6 in this tutorial. Here are some tutorials that will help you get set up:
-
-   - `Installing Python + Pip on Windows 10 <https://dbader.org/blog/installing-python-and-pip-on-windows-10>`__
-   - `Installing Python 3.6 on Ubuntu Linux <https://askubuntu.com/questions/865554/how-do-i-install-python-3-6-using-apt-get>`__
-   - On Mac OS, you should be able to download it from `python.org <https://www.python.org/downloads/>`_. 
+1. Have Python 3.6 installed in your laptop. **Note:** It's important that you're running Python 3.6 (or above) because we will use some of the new features added in 3.6 in this tutorial. 
+   
+   * `Here's a tutorial that will help you get set up <https://realpython.com/installing-python/)>`__
    
 2. Create a `GitHub <https://github.com/>`_ account, if you don't already have one.
    If your account has two-factor-authentication enabled, bring that device.


### PR DESCRIPTION
We published a detailed "how to install Python 3" tutorial on
Real Python that's based on the things we learned during the
workshop trial run in Vancouver.

This adds the link to preparation.rst